### PR TITLE
feature: convert getHistoryId return string into JSON Object (CALL-01)

### DIFF
--- a/src/main/java/com/autozone/cazss_backend/DTO/HistoryDataDTO.java
+++ b/src/main/java/com/autozone/cazss_backend/DTO/HistoryDataDTO.java
@@ -1,29 +1,29 @@
 package com.autozone.cazss_backend.DTO;
 
 public class HistoryDataDTO {
-  private String request;
-  private String response;
+  private Object request;
+  private Object response;
 
   public HistoryDataDTO() {}
 
-  public HistoryDataDTO(String request, String response) {
+  public HistoryDataDTO(Object request, Object response) {
     this.request = request;
     this.response = response;
   }
 
-  public String getRequest() {
+  public Object getRequest() {
     return request;
   }
 
-  public void setRequest(String request) {
+  public void setRequest(Object request) {
     this.request = request;
   }
 
-  public String getResponse() {
+  public Object getResponse() {
     return response;
   }
 
-  public void setResponse(String response) {
+  public void setResponse(Object response) {
     this.response = response;
   }
 }

--- a/src/main/java/com/autozone/cazss_backend/entity/HistoryDataEntity.java
+++ b/src/main/java/com/autozone/cazss_backend/entity/HistoryDataEntity.java
@@ -18,7 +18,7 @@ public class HistoryDataEntity {
   @Enumerated(EnumType.STRING)
   private HistoryDataTypeEnum type;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "LONGTEXT")
   @Lob
   private String content;
 

--- a/src/main/java/com/autozone/cazss_backend/exceptions/ParseJSONException.java
+++ b/src/main/java/com/autozone/cazss_backend/exceptions/ParseJSONException.java
@@ -1,0 +1,7 @@
+package com.autozone.cazss_backend.exceptions;
+
+public class ParseJSONException extends RuntimeException {
+  public ParseJSONException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/autozone/cazss_backend/model/BodyModel.java
+++ b/src/main/java/com/autozone/cazss_backend/model/BodyModel.java
@@ -26,4 +26,9 @@ public class BodyModel {
   public void setValue(String value) {
     this.value = value;
   }
+
+  @Override
+  public String toString() {
+    return "{\"key\":\"" + key + "\", \"value\":\"" + value + "\"}";
+  }
 }

--- a/src/main/java/com/autozone/cazss_backend/service/EndpointService.java
+++ b/src/main/java/com/autozone/cazss_backend/service/EndpointService.java
@@ -250,7 +250,11 @@ public class EndpointService {
         userRepository.getReferenceById(90); // TEST USER FOR FE. REPLACE WITH ACTUAL USER LATER
     EndpointsEntity endpoint = endpointsRepository.getReferenceById(id);
     historyService.addHistory(
-        user, endpoint, status.getCode(), serviceInfoRequestModel.toString(), "");
+        user,
+        endpoint,
+        status.getCode(),
+        serviceInfoRequestModel.getBody().toString(),
+        parsedResponse.toString());
     // SAVE IN HISTORY - END
 
     return new EndpointServiceDTO(status, parsedResponse);

--- a/src/main/java/com/autozone/cazss_backend/service/HistoryService.java
+++ b/src/main/java/com/autozone/cazss_backend/service/HistoryService.java
@@ -10,10 +10,12 @@ import com.autozone.cazss_backend.entity.HistoryEntity;
 import com.autozone.cazss_backend.entity.UserEntity;
 import com.autozone.cazss_backend.enumerator.HistoryDataTypeEnum;
 import com.autozone.cazss_backend.exceptions.HistoryNotFoundException;
+import com.autozone.cazss_backend.exceptions.ParseJSONException;
 import com.autozone.cazss_backend.projections.HistoryDetailedProjection;
 import com.autozone.cazss_backend.projections.HistoryProjection;
 import com.autozone.cazss_backend.repository.HistoryDataRepository;
 import com.autozone.cazss_backend.repository.HistoryRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,8 +75,17 @@ public class HistoryService {
             historyRequest.getName(),
             historyRequest.getDescription());
 
-    HistoryDataDTO historyData =
-        new HistoryDataDTO(historyRequest.getContent(), historyResponse.getContent());
+    ObjectMapper objectMapper = new ObjectMapper();
+    Object requestContent;
+    Object responseContent;
+    try {
+      requestContent = objectMapper.readValue(historyRequest.getContent(), Object.class);
+      responseContent = objectMapper.readValue(historyResponse.getContent(), Object.class);
+    } catch (Exception e) {
+      throw new ParseJSONException("Failed to parse history content");
+    }
+
+    HistoryDataDTO historyData = new HistoryDataDTO(requestContent, responseContent);
 
     return new HistoryDetailedDTO(
         historyRequest.getHistoryId(), historyRequest.getStatusCode(), endpoint, historyData);

--- a/src/main/java/com/autozone/cazss_backend/service/HistoryService.java
+++ b/src/main/java/com/autozone/cazss_backend/service/HistoryService.java
@@ -17,7 +17,9 @@ import com.autozone.cazss_backend.repository.HistoryDataRepository;
 import com.autozone.cazss_backend.repository.HistoryRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -77,15 +79,33 @@ public class HistoryService {
 
     ObjectMapper objectMapper = new ObjectMapper();
     Object requestContent;
-    Object responseContent;
     try {
       requestContent = objectMapper.readValue(historyRequest.getContent(), Object.class);
-      responseContent = objectMapper.readValue(historyResponse.getContent(), Object.class);
     } catch (Exception e) {
       throw new ParseJSONException("Failed to parse history content");
     }
 
-    HistoryDataDTO historyData = new HistoryDataDTO(requestContent, responseContent);
+    // PRARSE OBJECT INTO MORE PARSED REQUEST OBJECT FOR FRONTEND
+
+    Map<String, Object> parsedRequestContent = new HashMap<>();
+    if (requestContent instanceof List<?> list) {
+      for (Object obj : list) {
+        if (obj instanceof Map<?, ?> entry) {
+          Object k = entry.get("key");
+          Object v = entry.get("value");
+          if (k != null) {
+            parsedRequestContent.put(k.toString(), v);
+          }
+        }
+      }
+    }
+
+    // PRARSE OBJECT END
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("response", historyResponse.getContent());
+
+    HistoryDataDTO historyData = new HistoryDataDTO(parsedRequestContent, response);
 
     return new HistoryDetailedDTO(
         historyRequest.getHistoryId(), historyRequest.getStatusCode(), endpoint, historyData);

--- a/src/test/java/com/autozone/cazss_backend/controller/HistoryControllerIntegrationTest.java
+++ b/src/test/java/com/autozone/cazss_backend/controller/HistoryControllerIntegrationTest.java
@@ -17,6 +17,7 @@ import com.autozone.cazss_backend.repository.HistoryDataRepository;
 import com.autozone.cazss_backend.repository.HistoryRepository;
 import com.autozone.cazss_backend.repository.UserRepository;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class HistoryControllerIntegrationTest {
 
   @Autowired private MockMvc mockMvc;
@@ -43,10 +45,7 @@ public class HistoryControllerIntegrationTest {
 
   private HistoryEntity savedHistory;
 
-  private HistoryDataEntity savedHistoryDataEntityRequest;
-
-  private HistoryDataEntity savedHistoryDataEntityResponse;
-
+  @BeforeEach
   public void setup() {
     HistoryEntity history = new HistoryEntity();
     UserEntity user = new UserEntity();
@@ -80,23 +79,20 @@ public class HistoryControllerIntegrationTest {
     HistoryDataEntity historyDataEntityRequest = new HistoryDataEntity();
     historyDataEntityRequest.setHistory(savedHistory);
     historyDataEntityRequest.setType(HistoryDataTypeEnum.REQUEST);
-    historyDataEntityRequest.setContent("Request test");
-    savedHistoryDataEntityRequest = historyDataRepository.save(historyDataEntityRequest);
+    historyDataEntityRequest.setContent("{\"id\": 1}");
+    historyDataRepository.save(historyDataEntityRequest);
 
     HistoryDataEntity historyDataEntityResponse = new HistoryDataEntity();
     historyDataEntityResponse.setHistory(savedHistory);
     historyDataEntityResponse.setType(HistoryDataTypeEnum.RESPONSE);
-    historyDataEntityResponse.setContent("Response test");
-    savedHistoryDataEntityResponse = historyDataRepository.save(historyDataEntityResponse);
+    historyDataEntityResponse.setContent("{\"result\": \"ok\"}");
+    historyDataRepository.save(historyDataEntityResponse);
   }
 
-  @Transactional
   @Test
   public void testGetAllHistory() throws Exception {
-    setup();
     System.out.println("The saved history ID is the following:");
     System.out.println(savedHistory.getHistoryId());
-
     mockMvc
         .perform(get("/services/history").contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -108,16 +104,13 @@ public class HistoryControllerIntegrationTest {
                 .value(savedHistory.getEndpoint().getDescription()));
   }
 
-  @Transactional
   @Test
   public void testGetServiceById() throws Exception {
-    setup();
-    System.out.println("The saved history ID is the following:");
+    System.out.println("The saved history ID is the following2:");
     System.out.println(savedHistory.getHistoryId());
-
     mockMvc
         .perform(
-            get("/services/history/{id}", savedHistory.getHistoryId())
+            get("/services/history/" + savedHistory.getHistoryId())
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.historyId").value(savedHistory.getHistoryId()))
@@ -127,9 +120,7 @@ public class HistoryControllerIntegrationTest {
         .andExpect(jsonPath("$.endpoint.name").value(savedHistory.getEndpoint().getName()))
         .andExpect(
             jsonPath("$.endpoint.description").value(savedHistory.getEndpoint().getDescription()))
-        .andExpect(
-            jsonPath("$.historyData.request").value(savedHistoryDataEntityRequest.getContent()))
-        .andExpect(
-            jsonPath("$.historyData.response").value(savedHistoryDataEntityResponse.getContent()));
+        .andExpect(jsonPath("$.historyData.request").isMap())
+        .andExpect(jsonPath("$.historyData.response").isMap());
   }
 }

--- a/src/test/java/com/autozone/cazss_backend/controller/HistoryControllerIntegrationTest.java
+++ b/src/test/java/com/autozone/cazss_backend/controller/HistoryControllerIntegrationTest.java
@@ -106,7 +106,7 @@ public class HistoryControllerIntegrationTest {
 
   @Test
   public void testGetServiceById() throws Exception {
-    System.out.println("The saved history ID is the following2:");
+    System.out.println("The saved history ID is the following:");
     System.out.println(savedHistory.getHistoryId());
     mockMvc
         .perform(

--- a/src/test/java/com/autozone/cazss_backend/service/HistoryServiceTest.java
+++ b/src/test/java/com/autozone/cazss_backend/service/HistoryServiceTest.java
@@ -181,8 +181,8 @@ public class HistoryServiceTest {
     HistoryDetailedProjection responseProjection = mock(HistoryDetailedProjection.class);
 
     // Simulate JSON objects as strings
-    String requestJson = "{\"request\":\"data\"}";
-    String responseJson = "{\"response\":\"data\"}";
+    String requestJson = "[{\"key\": \"request\",\"value\": \"data\"}]";
+    String responseJson = "response data";
 
     when(requestProjection.getContent()).thenReturn(requestJson);
     when(responseProjection.getContent()).thenReturn(responseJson);
@@ -211,7 +211,7 @@ public class HistoryServiceTest {
     Map<String, Object> responseMap = (Map<String, Object>) result.getHistoryData().getResponse();
 
     assertEquals("data", requestMap.get("request"));
-    assertEquals("data", responseMap.get("response"));
+    assertEquals("response data", responseMap.get("response"));
   }
 
   @Test

--- a/src/test/java/com/autozone/cazss_backend/service/HistoryServiceTest.java
+++ b/src/test/java/com/autozone/cazss_backend/service/HistoryServiceTest.java
@@ -24,6 +24,7 @@ import com.autozone.cazss_backend.repository.HistoryDataRepository;
 import com.autozone.cazss_backend.repository.HistoryRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -200,16 +201,14 @@ public class HistoryServiceTest {
 
     // The request and response should be parsed as Map (Jackson default for
     // Object.class)
-    assertTrue(result.getHistoryData().getRequest() instanceof java.util.Map);
-    assertTrue(result.getHistoryData().getResponse() instanceof java.util.Map);
+    assertTrue(result.getHistoryData().getRequest() instanceof Map);
+    assertTrue(result.getHistoryData().getResponse() instanceof Map);
 
     // Optionally, check the actual content
     @SuppressWarnings("unchecked")
-    java.util.Map<String, Object> requestMap =
-        (java.util.Map<String, Object>) result.getHistoryData().getRequest();
+    Map<String, Object> requestMap = (Map<String, Object>) result.getHistoryData().getRequest();
     @SuppressWarnings("unchecked")
-    java.util.Map<String, Object> responseMap =
-        (java.util.Map<String, Object>) result.getHistoryData().getResponse();
+    Map<String, Object> responseMap = (Map<String, Object>) result.getHistoryData().getResponse();
 
     assertEquals("data", requestMap.get("request"));
     assertEquals("data", responseMap.get("response"));

--- a/src/test/java/com/autozone/cazss_backend/service/HistoryServiceTest.java
+++ b/src/test/java/com/autozone/cazss_backend/service/HistoryServiceTest.java
@@ -3,6 +3,7 @@ package com.autozone.cazss_backend.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -178,8 +179,12 @@ public class HistoryServiceTest {
     HistoryDetailedProjection requestProjection = mock(HistoryDetailedProjection.class);
     HistoryDetailedProjection responseProjection = mock(HistoryDetailedProjection.class);
 
-    when(requestProjection.getContent()).thenReturn("{\"id\":1}");
-    when(responseProjection.getContent()).thenReturn("{\"ok\":true}");
+    // Simulate JSON objects as strings
+    String requestJson = "{\"request\":\"data\"}";
+    String responseJson = "{\"response\":\"data\"}";
+
+    when(requestProjection.getContent()).thenReturn(requestJson);
+    when(responseProjection.getContent()).thenReturn(responseJson);
 
     when(historyRepository.findHistoryRequestByHistoryId(historyId))
         .thenReturn(Optional.of(requestProjection));
@@ -192,8 +197,22 @@ public class HistoryServiceTest {
     // Assert
     assertNotNull(result);
     assertNotNull(result.getHistoryData());
-    assertEquals("{\"id\":1}", result.getHistoryData().getRequest());
-    assertEquals("{\"ok\":true}", result.getHistoryData().getResponse());
+
+    // The request and response should be parsed as Map (Jackson default for
+    // Object.class)
+    assertTrue(result.getHistoryData().getRequest() instanceof java.util.Map);
+    assertTrue(result.getHistoryData().getResponse() instanceof java.util.Map);
+
+    // Optionally, check the actual content
+    @SuppressWarnings("unchecked")
+    java.util.Map<String, Object> requestMap =
+        (java.util.Map<String, Object>) result.getHistoryData().getRequest();
+    @SuppressWarnings("unchecked")
+    java.util.Map<String, Object> responseMap =
+        (java.util.Map<String, Object>) result.getHistoryData().getResponse();
+
+    assertEquals("data", requestMap.get("request"));
+    assertEquals("data", responseMap.get("response"));
   }
 
   @Test


### PR DESCRIPTION
(+ fix tests)

On the getHistoryById function, this was the previous vs current way info is returned:

previous:
```
"historyData": {
    "request": "{\"request\": \"data\"}",
    "response": "{\"response\": \"data\"}"
}
```

current:
```
"historyData": {
    "request": {
        "request": "data"
    },
    "response": {
        "response": "data"
    }
}
```

This fix helps the frontend team display items in a clearer way from the history call again right side menu.