### PR TITLE
chore: add Categories POST endpoint, DTO field validation, and add additional exception handlers (UCC-2)

### DIFF
--- a/src/main/java/com/autozone/cazss_backend/DTO/CategoryDTO.java
+++ b/src/main/java/com/autozone/cazss_backend/DTO/CategoryDTO.java
@@ -1,10 +1,15 @@
 package com.autozone.cazss_backend.DTO;
 
 import com.autozone.cazss_backend.entity.CategoryEntity;
+import jakarta.validation.constraints.NotBlank;
 
 public class CategoryDTO {
   private Integer categoryId;
+
+  @NotBlank(message = "Category name is required")
   private String name;
+
+  @NotBlank(message = "Category color is required")
   private String color;
 
   public CategoryDTO() {}

--- a/src/main/java/com/autozone/cazss_backend/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/autozone/cazss_backend/advice/GlobalExceptionHandler.java
@@ -59,18 +59,33 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(
-      CategoryNotFoundException.class) // Excepción de acceso no autorizado a un endpoint
+      CategoryNotFoundException.class) // Excepción de categoría no encontrada en alguna operación
   public ResponseEntity<Object> handleValidationException(final CategoryNotFoundException ex) {
     // Crear el objeto ErrorResponse
     ErrorResponseTemplate error =
         new ErrorResponseTemplate(
-            "VALIDATION_ERROR",
+            "CATEGORY_DOES_NOT_EXIST",
             ex.getMessage(),
             "No such category was found.",
             LocalDateTime.now(),
             UUID.randomUUID().toString());
 
     return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(
+      CategoryAlreadyExistsException.class) // Excepción de acceso no autorizado a un endpoint
+  public ResponseEntity<Object> handleValidationException(final CategoryAlreadyExistsException ex) {
+    // Crear el objeto ErrorResponse
+    ErrorResponseTemplate error =
+        new ErrorResponseTemplate(
+            "CATEGORY_ALREADY_EXISTS",
+            ex.getMessage(),
+            "Can't create category with already existing name.",
+            LocalDateTime.now(),
+            UUID.randomUUID().toString());
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(AZClientException.class) // Excepción de AZClient
@@ -109,7 +124,7 @@ public class GlobalExceptionHandler {
       final MissingRequestHeaderException ex) {
     ErrorResponseTemplate error =
         new ErrorResponseTemplate(
-            "VALIDATION_ERROR",
+            "MISSING_REQUEST_HEADER",
             ex.getMessage(),
             "Missing headers during endpoint call",
             LocalDateTime.now(),

--- a/src/main/java/com/autozone/cazss_backend/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/autozone/cazss_backend/advice/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -97,6 +98,20 @@ public class GlobalExceptionHandler {
             "VALIDATION_ERROR",
             defaultMessage,
             "Detalles del error de validación",
+            LocalDateTime.now(),
+            UUID.randomUUID().toString());
+
+    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class) // Excepción de bad request
+  public ResponseEntity<Object> handleMethodArgumentNotValid(
+      final MissingRequestHeaderException ex) {
+    ErrorResponseTemplate error =
+        new ErrorResponseTemplate(
+            "VALIDATION_ERROR",
+            ex.getMessage(),
+            "Missing headers during endpoint call",
             LocalDateTime.now(),
             UUID.randomUUID().toString());
 

--- a/src/main/java/com/autozone/cazss_backend/controller/CategoryController.java
+++ b/src/main/java/com/autozone/cazss_backend/controller/CategoryController.java
@@ -7,6 +7,7 @@ import com.autozone.cazss_backend.service.UserCategoryService;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,8 +42,10 @@ public class CategoryController {
    * @return CategoryDTO of the specified category with the newly provided name and color
    */
   @PostMapping("")
-  public ResponseEntity<CategoryDTO> createCategory(@RequestBody CategoryDTO categoryDTO) {
-    return new ResponseEntity<>(new CategoryDTO(), HttpStatus.CREATED);
+  public ResponseEntity<CategoryDTO> createCategory(
+      @RequestHeader("userId") Integer userId, @Valid @RequestBody CategoryDTO categoryDTO) {
+    return new ResponseEntity<>(
+        categoryService.createCategory(userId, categoryDTO), HttpStatus.CREATED);
   }
 
   /**
@@ -67,7 +70,7 @@ public class CategoryController {
    */
   @DeleteMapping("/{categoryId}")
   public ResponseEntity<String> deleteCategory(
-      @RequestHeader Integer userId, @PathVariable Integer categoryId) {
+      @RequestHeader @NotNull Integer userId, @PathVariable @NotNull Integer categoryId) {
     return new ResponseEntity<>(categoryService.deleteCategory(userId, categoryId), HttpStatus.OK);
   }
 

--- a/src/main/java/com/autozone/cazss_backend/exceptions/CategoryAlreadyExistsException.java
+++ b/src/main/java/com/autozone/cazss_backend/exceptions/CategoryAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.autozone.cazss_backend.exceptions;
+
+public class CategoryAlreadyExistsException extends RuntimeException {
+  public CategoryAlreadyExistsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/autozone/cazss_backend/service/CategoryService.java
+++ b/src/main/java/com/autozone/cazss_backend/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.autozone.cazss_backend.DTO.CategoryDTO;
 import com.autozone.cazss_backend.entity.CategoryEntity;
 import com.autozone.cazss_backend.entity.EndpointsEntity;
 import com.autozone.cazss_backend.entity.UserCategoryEntity;
+import com.autozone.cazss_backend.exceptions.CategoryAlreadyExistsException;
 import com.autozone.cazss_backend.exceptions.CategoryNotFoundException;
 import com.autozone.cazss_backend.exceptions.UnauthorizedUserException;
 import com.autozone.cazss_backend.repository.CategoryRepository;
@@ -63,7 +64,17 @@ public class CategoryService {
 
   @Transactional
   public CategoryDTO createCategory(Integer userId, CategoryDTO categoryDTO) {
-    return new CategoryDTO();
+    // Check if category name already exists
+    if (categoryRepository.findByName(categoryDTO.getName()).isPresent()) {
+      throw new CategoryAlreadyExistsException(
+          "Category with name '" + categoryDTO.getName() + "' already exists.");
+    }
+
+    CategoryEntity categoryEntity =
+        new CategoryEntity(categoryDTO.getName(), categoryDTO.getColor());
+    CategoryEntity savedCategory = categoryRepository.save(categoryEntity);
+    return new CategoryDTO(
+        savedCategory.getCategoryId(), savedCategory.getName(), savedCategory.getColor());
   }
 
   @Transactional

--- a/src/test/java/com/autozone/cazss_backend/controller/CategoryControllerIntegrationTest.java
+++ b/src/test/java/com/autozone/cazss_backend/controller/CategoryControllerIntegrationTest.java
@@ -152,4 +152,37 @@ public class CategoryControllerIntegrationTest {
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$.length()").value(1));
   }
+
+  @Transactional
+  @Test
+  public void testDeleteCategory_CategoryNotFound_ShouldReturnNotFound() throws Exception {
+    UserEntity user = new UserEntity();
+    user.setEmail("notfound" + UUID.randomUUID() + "@autozone.com");
+    user.setActive(true);
+    user.setRole(UserRoleEnum.ADMIN);
+    userRepository.save(user);
+
+    int nonExistentCategoryId = 999999;
+
+    mockMvc
+        .perform(
+            delete("/categories/{categoryId}", nonExistentCategoryId)
+                .header("userId", user.getUserId()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("No category found")); // Ajusta según tu handler
+  }
+
+  @Transactional
+  @Test
+  public void testDeleteCategory_MissingUserIdHeader_ShouldReturnBadRequest() throws Exception {
+    CategoryEntity category = new CategoryEntity();
+    category.setName("MissingUserTest" + UUID.randomUUID());
+    category.setColor("#FFFFFF");
+    categoryRepository.save(category);
+
+    mockMvc
+        .perform(delete("/categories/{categoryId}", category.getCategoryId()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").exists());
+  }
 }


### PR DESCRIPTION
CategoryDTO should NOT be forced to include an ID, SPECIFICALLY for category creation. The client is not meant to know what ID we'll assign them. ALSO, added a MissingRequestHeaderException handler.